### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Branches night mode there is a problem, since you do not want to repeat the same
 Thanks tngou api interface [http://www.tngou.net/doc/gallery](http://www.tngou.net/doc/gallery)
 
 
-#Description Framework
+# Description Framework
 
 	androidSupport
 	glide


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
